### PR TITLE
admin_permission Attribut wird ausgewertet

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -11,6 +11,7 @@
 + Fast Mode hinzugefügt (Verbesserung der Performance durch Deaktivierung bestimmter Funktionen)
 + Performance verbessert
 + "Nachricht des Tages" nutzt nun den HTML-Editor
++ "admin_permission" Attribut in metadata.json wird nun unterstützt
 # Sende Error 403 bei fehlgeschlagenem Login
 # Unique Index zu der Spalte "name" der setttings-Tabelle hinzugefügt
 - Feld für ICQ-UID entfernt

--- a/ulicms/admin/inc/adminmenu.php
+++ b/ulicms/admin/inc/adminmenu.php
@@ -1,10 +1,18 @@
 <?php
 if (defined ( "_SECURITY" )) {
+	$acl = new ACL ();
 	$modules = getAllModules ();
 	$modules_with_admin_page = Array ();
 	for($i = 0; $i < count ( $modules ); $i ++) {
 		if (file_exists ( getModuleAdminFilePath ( $modules [$i] ) ) or file_exists ( getModuleAdminFilePath2 ( $modules [$i] ) )) {
-			array_push ( $modules_with_admin_page, $modules [$i] );
+			$admin_permission = getModuleMeta ( $modules [$i], "admin_permission" );
+			$allowed = true;
+			if (isNotNullOrEmpty ( $admin_permission )) {
+				$allowed = $acl->hasPermission ( $admin_permission );
+			}
+			if ($allowed) {
+				array_push ( $modules_with_admin_page, $modules [$i] );
+			}
 		}
 	}
 	

--- a/ulicms/admin/inc/module_settings.php
+++ b/ulicms/admin/inc/module_settings.php
@@ -27,8 +27,14 @@ if (! file_exists ( $admin_file_path ) and ! file_exists ( $admin_file_path2 )) 
 	}
 	
 	$acl = new ACL ();
-	
-	if (defined ( "MODULE_ADMIN_REQUIRED_PERMISSION" )) {
+	$admin_permission = getModuleMeta ( $module, "admin_permission" );
+	if ($admin_permission) {
+		if ($acl->hasPermission ( $admin_permission )) {
+			define ( "MODULE_ACCESS_PERMITTED", true );
+		} else {
+			define ( "MODULE_ACCESS_PERMITTED", false );
+		}
+	} else if (defined ( "MODULE_ADMIN_REQUIRED_PERMISSION" )) {
 		if ($acl->hasPermission ( MODULE_ADMIN_REQUIRED_PERMISSION ) and $acl->hasPermission ( "module_settings" )) {
 			define ( "MODULE_ACCESS_PERMITTED", true );
 		} else {


### PR DESCRIPTION
admin_permission Attribut wird ausgewertet. Menüeinträge der Module werden ausgeblendet, wenn keine Berechtigung vorhanden ist.